### PR TITLE
Add a logback-test.xml file to supress logback during tests, hopefully

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 before_script: ./build.sh pom.xml
-script: export MAVEN_OPTS="-Xmx1024m" && mvn test --quiet
+script: export MAVEN_OPTS="-Xmx1024m" && mvn test --quiet -Dlogback.configurationFile=test/resources/logback-test.xml
 addons:
   hostname: short-hostname
 jdk:

--- a/test/resources/logback-test.xml
+++ b/test/resources/logback-test.xml
@@ -1,0 +1,1 @@
+<configuration />


### PR DESCRIPTION
this will help speed things up a bit.
Also mock out the timer and threads in TestFsck as it wasn't before!

Also remove the precise limiter.

Signed-off-by: Chris Larsen <clarsen@yahoo-inc.com>